### PR TITLE
Change time unit to seconds

### DIFF
--- a/lib/minitest/profile_plugin.rb
+++ b/lib/minitest/profile_plugin.rb
@@ -34,7 +34,7 @@ module Minitest
       puts "=" * 80
       puts
       sorted_results[0,10].each do |time, test_name|
-        puts "#{sprintf("%7.4f",time)}ms - #{test_name}"
+        puts "#{sprintf("%7.4f",time).truncate(2)} s - #{test_name}"
       end
 
       puts


### PR DESCRIPTION
* The slow test time is actually output in seconds, not milliseconds so
  change ms to s in the output
* Also truncate the decimal so that it's only 2 places